### PR TITLE
fix: trim task title in complete_task()

### DIFF
--- a/examples/run_task_manager.rs
+++ b/examples/run_task_manager.rs
@@ -1,0 +1,32 @@
+use task_manager::TaskManager;
+
+fn main() {
+    // Initialize the task manager
+    let mut tm = TaskManager::new();
+
+    // Add tasks
+    let id1 = tm.add_task("  Buy milk  ".to_string());
+    let id2 = tm.add_task("Walk the dog".to_string());
+
+    println!("Tasks added:");
+    for id in &[id1, id2] {
+        let task = tm.get_task(*id).unwrap();
+        println!("  {}: {:?}", id, task);
+    }
+
+    // Complete a task
+    tm.complete_task(id1).unwrap();
+
+    // Show updated tasks
+    println!("\nAfter completing task {}:", id1);
+    for id in &[id1, id2] {
+        let task = tm.get_task(*id).unwrap();
+        println!("  {}: {:?}", id, task);
+    }
+
+    // Try to complete a non-existent task
+    match tm.complete_task(999) {
+        Ok(_) => println!("Unexpectedly succeeded on invalid task"),
+        Err(e) => println!("Failed to complete non-existent task (expected): {:?}", e),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ impl TaskManager {
     pub fn complete_task(&mut self, id: u32) -> Result<(), TaskError> {
         match self.tasks.get_mut(&id) {
             Some(task) => {
+                task.title = task.title.trim().to_string(); // fix
                 task.done = true;
                 Ok(())
             }

--- a/tests/task_manager_tests.rs
+++ b/tests/task_manager_tests.rs
@@ -1,0 +1,20 @@
+use task_manager::TaskManager;
+
+#[test]
+fn test_add_and_complete_task() {
+    let mut tm = TaskManager::new();
+    let id = tm.add_task("  Buy milk  ".to_string());
+    
+    tm.complete_task(id).unwrap();
+    let task = tm.get_task(id).unwrap();
+    
+    assert_eq!(task.title, "Buy milk"); // ✅ now passes
+    assert!(task.done);
+}
+
+#[test]
+fn test_complete_nonexistent_task() {
+    let mut tm = TaskManager::new();
+    let result = tm.complete_task(999);
+    assert!(matches!(result, Err(_)));
+}


### PR DESCRIPTION
Fixes issue #1: trim task title when completing a task

- Updated `complete_task()` to trim leading/trailing whitespace
- Added unit tests:
  - task completion trims title
  - completing non-existent task returns error
- Added integration example demonstrating proper title trimming