### PR TITLE
feat: add delete_task() method to Task Manager

### DIFF
--- a/examples/run_task_manager.rs
+++ b/examples/run_task_manager.rs
@@ -1,3 +1,4 @@
+ 
 use task_manager::TaskManager;
 
 fn main() {
@@ -21,6 +22,15 @@ fn main() {
     println!("\nAfter completing task {}:", id1);
     for id in &[id1, id2] {
         let task = tm.get_task(*id).unwrap();
+        println!("  {}: {:?}", id, task);
+    }
+        // Delete a task
+    println!("\nDeleting task {}...", id2);
+    tm.delete_task(id2).unwrap();
+
+    // Show tasks after deletion
+    println!("\nTasks after deletion:");
+    for (id, task) in tm.all_tasks() {
         println!("  {}: {:?}", id, task);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+ 
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
@@ -46,8 +47,18 @@ impl TaskManager {
     pub fn get_task(&self, id: u32) -> Result<&Task, TaskError> {
         self.tasks.get(&id).ok_or(TaskError::NotFound)
     }
-}
 
+pub fn delete_task(&mut self, id: u32) -> Result<(), TaskError> {
+    match self.tasks.remove(&id) {
+        Some(_) => Ok(()),
+        None => Err(TaskError::NotFound),
+    }
+}
+    pub fn all_tasks(&self) -> impl Iterator<Item = (&u32, &Task)> {
+        self.tasks.iter()
+    }
+
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -56,10 +67,10 @@ mod tests {
     fn test_add_and_complete_task() {
         let mut tm = TaskManager::new();
         let id = tm.add_task("  Buy milk  ".to_string());
-        
+
         tm.complete_task(id).unwrap();
         let task = tm.get_task(id).unwrap();
-        
+
         assert_eq!(task.title, "Buy milk");
         assert!(task.done);
     }
@@ -69,5 +80,28 @@ mod tests {
         let mut tm = TaskManager::new();
         let result = tm.complete_task(999);
         assert!(matches!(result, Err(_)));
+    }
+
+    #[test]
+    fn test_delete_existing_task() {
+        let mut tm = TaskManager::new();
+        let id = tm.add_task("Buy milk".to_string());
+
+        // delete the task
+        let result = tm.delete_task(id);
+        assert!(result.is_ok());
+
+        // task should no longer exist
+        let task = tm.get_task(id);
+        assert!(task.is_err());
+    }
+
+    #[test]
+    fn test_delete_nonexistent_task() {
+        let mut tm = TaskManager::new();
+
+        // deleting a non-existent task should return Err
+        let result = tm.delete_task(999);
+        assert!(matches!(result, Err(TaskError::NotFound)));
     }
 }

--- a/tests/task_manager_tests.rs
+++ b/tests/task_manager_tests.rs
@@ -8,7 +8,7 @@ fn test_add_and_complete_task() {
     tm.complete_task(id).unwrap();
     let task = tm.get_task(id).unwrap();
     
-    assert_eq!(task.title, "Buy milk"); // ✅ now passes
+    assert_eq!(task.title, "Buy milk"); // now passes clean
     assert!(task.done);
 }
 
@@ -16,5 +16,20 @@ fn test_add_and_complete_task() {
 fn test_complete_nonexistent_task() {
     let mut tm = TaskManager::new();
     let result = tm.complete_task(999);
+    assert!(matches!(result, Err(_)));
+}
+#[test]
+fn test_delete_existing_task() {
+    let mut tm = TaskManager::new();
+    let id = tm.add_task("Buy eggs".to_string());
+
+    assert!(tm.delete_task(id).is_ok());
+    assert!(tm.get_task(id).is_err());
+}
+
+#[test]
+fn test_delete_nonexistent_task() {
+    let mut tm = TaskManager::new();
+    let result = tm.delete_task(12345);
     assert!(matches!(result, Err(_)));
 }


### PR DESCRIPTION
Fixes #3: add support for deleting tasks

- Added `delete_task()` method
- Returns Ok if deleted, Err(TaskError::NotFound) if missing
- Added tests for deleting existing and non-existent tasks

---

### 📸 Screenshots
Before deletion:
<img width="1181" height="369" alt="before-deletion" src="https://github.com/user-attachments/assets/9ce8f107-793f-4365-b620-5b0d714e9e25" />

After deletion:
<img width="1185" height="495" alt="after-deletion" src="https://github.com/user-attachments/assets/5f498e27-9806-4649-9788-80102ab682cc" />

---

### 🎥 Demo Video
https://github.com/user-attachments/assets/4fa4da74-ad1c-41c8-b7c1-1b7265ca58cb
